### PR TITLE
Add jsonschema to requirements file it was needed by ipython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ scikit-learn==0.16.0
 scipy==0.15.1
 six==1.9.0
 tornado==4.1
+jsonschema==2.4.0


### PR DESCRIPTION
When installing all deps in a python3 ve for doing the classwork ipython failed to start for missing dep of jsonschema
